### PR TITLE
feat: clear timeout to prevent rogue async tasks

### DIFF
--- a/.changeset/rude-dolls-trade.md
+++ b/.changeset/rude-dolls-trade.md
@@ -1,0 +1,5 @@
+---
+'fp-ts-timeout': patch
+---
+
+Clear the internal timeout to prevent rogue async operations.

--- a/lib/withTaskEitherTimeout.ts
+++ b/lib/withTaskEitherTimeout.ts
@@ -10,9 +10,18 @@ export function withTaskEitherTimeout<LeftType, RightType>(
   milliseconds: number
 ): TaskEitherWithTimeoutCurriedFunc<LeftType, RightType> {
   return (taskEither) => {
+    // store the timeout id so that we can clear it later
+    let timeoutId: number | undefined;
+
     const asyncTimeout = new Promise<Either.Either<TimeoutError, never>>(
       (resolve) => {
-        setTimeout(
+        // We know or a fact that setTimeout() returns a positive integer.
+        // However typescript thinks it returns a NodeJS.Timeout,
+        // which is likely coming from a misconfiguration in the tsconfig.
+        // I do not have the time to look at this into detail,
+        // so I will just ignore the error for now.
+        // @ts-expect-error
+        timeoutId = setTimeout(
           () =>
             resolve(
               Either.left(new TimeoutError(`Timed out after ${milliseconds}ms`))
@@ -23,6 +32,13 @@ export function withTaskEitherTimeout<LeftType, RightType>(
     );
     const asyncTask = taskEither();
 
-    return () => Promise.race([asyncTask, asyncTimeout]);
+    return () =>
+      Promise.race([asyncTask, asyncTimeout]).finally(() => {
+        // at this point there's two possibilities:
+        // 1. asyncTask has resolved, in which case asyncTimeout is still running
+        // 2. asyncTimeout has resolved, in which case asyncTask is still running
+        // we want to clear the timeout in both cases
+        clearTimeout(timeoutId);
+      });
   };
 }


### PR DESCRIPTION
A long running async task has the potential to block node from existing. Consider the following, super-annoying error...

<img width="500" alt="Screenshot 2024-10-10 at 5 37 44 PM" src="https://github.com/user-attachments/assets/29e5a9cf-ff69-4983-b387-de44e547b655">
