### PR TITLE
chore: convert package to ESM

### DIFF
--- a/.changeset/dull-numbers-smell.md
+++ b/.changeset/dull-numbers-smell.md
@@ -1,0 +1,5 @@
+---
+'fp-ts-timeout': major
+---
+
+Converts the module to an ES module

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "fp-ts-timeout",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fp-ts-timeout",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
+      "dependencies": {
+        "p-retry": "^6.2.1"
+      },
       "devDependencies": {
         "@changesets/changelog-github": "^0.5.0",
         "@changesets/cli": "^2.27.7",
@@ -24,7 +27,6 @@
         "husky": "^8.0.3",
         "jest-fp-ts-matchers": "^0.5.0",
         "lint-staged": "^15.0.1",
-        "p-retry": "^6.2.1",
         "prettier": "^2.8.8",
         "rimraf": "^5.0.1",
         "tsup": "^8.4.0",
@@ -1895,7 +1897,6 @@
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
       "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/semver": {
@@ -5166,7 +5167,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.1.0.tgz",
       "integrity": "sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -6587,7 +6587,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
       "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/retry": "0.12.2",
@@ -7338,7 +7337,6 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "vitest": "^3.0.8"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
         "fp-ts": "^2.16.9"

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "vitest": "^3.0.8"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "fp-ts": "^2.16.9"

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "fp-ts-timeout",
   "version": "0.2.0",
   "description": "Timeout and retry functionality for fp-ts async structures",
@@ -81,7 +82,6 @@
     "husky": "^8.0.3",
     "jest-fp-ts-matchers": "^0.5.0",
     "lint-staged": "^15.0.1",
-    "p-retry": "^6.2.1",
     "prettier": "^2.8.8",
     "rimraf": "^5.0.1",
     "tsup": "^8.4.0",
@@ -90,5 +90,8 @@
   },
   "peerDependencies": {
     "fp-ts": "^2.16.9"
+  },
+  "dependencies": {
+    "p-retry": "^6.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "sideEffects": false,
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
     }
   ],
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "require": "./dist/index.js",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "type": "module",
   "name": "fp-ts-timeout",
   "version": "0.2.0",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "description": "Timeout and retry functionality for fp-ts async structures",
   "keywords": [
     "fp-ts",
@@ -28,16 +30,6 @@
       "url": "https://github.com/NikosTsompanides"
     }
   ],
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.js"
-    }
-  },
   "files": [
     "dist"
   ],
@@ -46,7 +38,7 @@
   },
   "sideEffects": false,
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,5 +8,4 @@ export default defineConfig({
   format: ['cjs', 'esm'],
   dts: true,
   outDir: 'dist',
-  noExternal: ['p-retry'],
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   splitting: false,
   sourcemap: true,
   clean: true,
-  format: ['cjs', 'esm'],
+  format: ['esm'],
   dts: true,
   outDir: 'dist',
 });


### PR DESCRIPTION
This PR converts the `fp-ts-timeout` package to an ES module.